### PR TITLE
Add simple RPA automation framework

### DIFF
--- a/examples/hello.json
+++ b/examples/hello.json
@@ -1,0 +1,5 @@
+[
+  {"action": "log", "args": {"message": "Inicio del flujo"}},
+  {"action": "delay", "args": {"seconds": 1}},
+  {"action": "log", "args": {"message": "Fin"}}
+]

--- a/rpa/README.md
+++ b/rpa/README.md
@@ -1,0 +1,14 @@
+# Simple RPA Framework
+
+Este es un ejemplo de una plataforma de Automatización Robótica de Procesos (RPA) escrita en Python inspirada en proyectos como Rocketbot.
+
+## Uso
+
+1. Defina un flujo en formato JSON, por ejemplo `examples/hello.json`.
+2. Ejecute el flujo con:
+
+```bash
+python -m rpa.cli examples/hello.json
+```
+
+Esto ejecutará las acciones registradas en orden.

--- a/rpa/__init__.py
+++ b/rpa/__init__.py
@@ -1,0 +1,15 @@
+"""Simple RPA framework inspired by Rocketbot style."""
+
+from .actions import action, get_action, Action, Delay, Log
+from .workflow import Workflow
+from .loader import load_workflow
+
+__all__ = [
+    "action",
+    "get_action",
+    "Action",
+    "Delay",
+    "Log",
+    "Workflow",
+    "load_workflow",
+]

--- a/rpa/actions.py
+++ b/rpa/actions.py
@@ -1,0 +1,60 @@
+"""Definitions of actions available to robots."""
+
+from __future__ import annotations
+
+import time
+from abc import ABC, abstractmethod
+from typing import Any, Callable, Dict, Type
+
+_action_registry: Dict[str, Type["Action"]] = {}
+
+
+def action(name: str) -> Callable[[Type["Action"]], Type["Action"]]:
+    """Register an action class under *name*.
+
+    Decorator used for plugin-style registration of actions.
+    """
+
+    def decorator(cls: Type["Action"]) -> Type["Action"]:
+        _action_registry[name] = cls
+        return cls
+
+    return decorator
+
+
+def get_action(name: str) -> Type["Action"]:
+    """Retrieve an action class previously registered."""
+    try:
+        return _action_registry[name]
+    except KeyError as exc:
+        raise KeyError(f"Unknown action: {name}") from exc
+
+
+class Action(ABC):
+    """Base class for all actions."""
+
+    @abstractmethod
+    def run(self, context: Dict[str, Any]) -> None:
+        """Execute the action."""
+
+
+@action("log")
+class Log(Action):
+    """Print a message to stdout."""
+
+    def __init__(self, message: str) -> None:
+        self.message = message
+
+    def run(self, context: Dict[str, Any]) -> None:  # pragma: no cover - simple print
+        print(self.message)
+
+
+@action("delay")
+class Delay(Action):
+    """Pause execution for a number of *seconds*."""
+
+    def __init__(self, seconds: float) -> None:
+        self.seconds = seconds
+
+    def run(self, context: Dict[str, Any]) -> None:
+        time.sleep(self.seconds)

--- a/rpa/cli.py
+++ b/rpa/cli.py
@@ -1,0 +1,19 @@
+"""Command line interface for running workflows."""
+
+from __future__ import annotations
+
+import argparse
+
+from .loader import load_workflow
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Simple RPA runner")
+    parser.add_argument("script", help="Path to JSON workflow definition")
+    args = parser.parse_args()
+    workflow = load_workflow(args.script)
+    workflow.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/rpa/loader.py
+++ b/rpa/loader.py
@@ -1,0 +1,23 @@
+"""Utility to load workflows from JSON definitions."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, Iterable
+
+from .actions import get_action
+from .workflow import Workflow
+
+
+def load_workflow(path: str | Path) -> Workflow:
+    """Load a workflow from a JSON file."""
+    with open(path, "r", encoding="utf-8") as fh:
+        data: Iterable[Dict[str, Any]] = json.load(fh)
+    wf = Workflow()
+    for step in data:
+        action_name: str = step["action"]
+        args: Dict[str, Any] = step.get("args", {})
+        action_cls = get_action(action_name)
+        wf.add_step(action_cls(**args))
+    return wf

--- a/rpa/workflow.py
+++ b/rpa/workflow.py
@@ -1,0 +1,23 @@
+"""Execution engine for workflows."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List
+
+from .actions import Action
+
+
+@dataclass
+class Workflow:
+    """A sequence of actions to be executed."""
+
+    steps: List[Action] = field(default_factory=list)
+
+    def add_step(self, action: Action) -> None:
+        self.steps.append(action)
+
+    def run(self, context: Dict[str, any] | None = None) -> None:
+        ctx: Dict[str, any] = context or {}
+        for action in self.steps:
+            action.run(ctx)


### PR DESCRIPTION
## Summary
- add minimal RPA framework with pluggable actions and workflow runner
- include JSON workflow loader and CLI interface
- provide example workflow demonstrating log and delay actions

## Testing
- `python -m pytest`
- `python -m rpa.cli examples/hello.json`


------
https://chatgpt.com/codex/tasks/task_e_689981ab188c8327b518d29c025dfb23