### PR TITLE
feat: agregar prototipo web RPA Studio Lite (MVP UI)

### DIFF
--- a/rpa_studio/README.md
+++ b/rpa_studio/README.md
@@ -1,0 +1,24 @@
+# RPA Studio Lite (Prototipo)
+
+Pequeño prototipo web inspirado en herramientas como UiPath/Rocketbot/Blue Prism.
+
+## Qué incluye
+
+- Panel de actividades con búsqueda.
+- Canvas para diseñar flujo arrastrando actividades.
+- Inspector de propiedades para editar nombre y parámetros de cada bloque.
+- Simulación de ejecución (log en pantalla).
+- Exportación de automatización a archivo JSON.
+
+## Ejecutar
+
+Desde la raíz del repositorio:
+
+```bash
+python3 -m http.server 8000
+```
+
+Luego abrir en el navegador:
+
+- `http://localhost:8000/rpa_studio/`
+

--- a/rpa_studio/app.js
+++ b/rpa_studio/app.js
@@ -1,0 +1,145 @@
+const canvas = document.getElementById('canvas');
+const log = document.getElementById('log');
+const runBtn = document.getElementById('runBtn');
+const saveBtn = document.getElementById('saveBtn');
+const search = document.getElementById('search');
+
+const propEmpty = document.getElementById('propEmpty');
+const propForm = document.getElementById('propForm');
+const propName = document.getElementById('propName');
+const propParams = document.getElementById('propParams');
+
+const activities = [...document.querySelectorAll('.activity')];
+let flow = [
+  { id: crypto.randomUUID(), type: 'start', name: 'Inicio', params: {} },
+];
+let selectedId = null;
+
+const defaultNames = {
+  start: 'Inicio',
+  if: 'Condición If',
+  for: 'Bucle For Each',
+  while: 'Bucle While',
+  wait: 'Esperar',
+  end: 'Fin',
+  'open-browser': 'Abrir Navegador',
+  click: 'Click Elemento',
+  write: 'Escribir Texto',
+};
+
+function renderFlow() {
+  canvas.innerHTML = '';
+
+  flow.forEach((node) => {
+    const card = document.createElement('article');
+    card.className = `node ${selectedId === node.id ? 'selected' : ''}`;
+    card.dataset.id = node.id;
+    card.innerHTML = `
+      <div class="node-title">${node.name}</div>
+      <div class="node-subtitle">${node.type}</div>
+    `;
+
+    card.addEventListener('click', () => {
+      selectedId = node.id;
+      renderProperties();
+      renderFlow();
+    });
+
+    canvas.appendChild(card);
+  });
+}
+
+function renderProperties() {
+  const node = flow.find((item) => item.id === selectedId);
+  if (!node) {
+    propEmpty.classList.remove('hidden');
+    propForm.classList.add('hidden');
+    return;
+  }
+
+  propEmpty.classList.add('hidden');
+  propForm.classList.remove('hidden');
+  propName.value = node.name;
+  propParams.value = JSON.stringify(node.params, null, 2);
+}
+
+activities.forEach((activity) => {
+  activity.addEventListener('dragstart', (event) => {
+    event.dataTransfer.setData('text/plain', activity.dataset.type);
+  });
+});
+
+canvas.addEventListener('dragover', (event) => {
+  event.preventDefault();
+});
+
+canvas.addEventListener('drop', (event) => {
+  event.preventDefault();
+  const type = event.dataTransfer.getData('text/plain');
+
+  if (!type) {
+    return;
+  }
+
+  flow.push({
+    id: crypto.randomUUID(),
+    type,
+    name: defaultNames[type] || type,
+    params: {},
+  });
+  renderFlow();
+});
+
+propForm.addEventListener('submit', (event) => {
+  event.preventDefault();
+  const index = flow.findIndex((node) => node.id === selectedId);
+
+  if (index === -1) {
+    return;
+  }
+
+  try {
+    flow[index].name = propName.value.trim() || flow[index].name;
+    flow[index].params = propParams.value.trim() ? JSON.parse(propParams.value) : {};
+    log.textContent = `✔ Bloque "${flow[index].name}" actualizado.`;
+    renderFlow();
+  } catch {
+    log.textContent = '✖ JSON inválido en parámetros.';
+  }
+});
+
+runBtn.addEventListener('click', () => {
+  const now = new Date().toLocaleTimeString('es-AR');
+  const lines = flow.map((step, index) => `${index + 1}. ${step.name} (${step.type})`);
+  log.textContent = [`[${now}] Ejecutando flujo...`, ...lines, `[${now}] Flujo finalizado.`].join('\n');
+});
+
+saveBtn.addEventListener('click', () => {
+  const automationName = document.getElementById('automationName').value || 'automatizacion';
+  const payload = {
+    name: automationName,
+    version: 1,
+    updatedAt: new Date().toISOString(),
+    flow,
+  };
+
+  const blob = new Blob([JSON.stringify(payload, null, 2)], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = `${automationName.toLowerCase().replaceAll(' ', '_')}.json`;
+  a.click();
+  URL.revokeObjectURL(url);
+  log.textContent = '✔ Automatización exportada en JSON.';
+});
+
+search.addEventListener('input', () => {
+  const query = search.value.toLowerCase().trim();
+  activities.forEach((item) => {
+    const visible = item.textContent.toLowerCase().includes(query);
+    item.style.display = visible ? 'block' : 'none';
+  });
+});
+
+renderFlow();
+renderProperties();

--- a/rpa_studio/index.html
+++ b/rpa_studio/index.html
@@ -1,0 +1,72 @@
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>RPA Studio Lite</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <header class="topbar">
+      <button class="icon-btn" id="backBtn" aria-label="Volver">←</button>
+      <input id="automationName" value="Nueva Automatización" />
+      <div class="actions">
+        <button class="ghost">Plantillas</button>
+        <button class="ghost" id="saveBtn">Guardar</button>
+        <button class="primary" id="runBtn">Ejecutar</button>
+      </div>
+    </header>
+
+    <main class="workspace">
+      <aside class="sidebar">
+        <h2>ACTIVIDADES</h2>
+        <input id="search" placeholder="Buscar actividad..." />
+
+        <section class="group">
+          <h3>Control de Flujo</h3>
+          <div class="activity" draggable="true" data-type="start">Inicio</div>
+          <div class="activity" draggable="true" data-type="if">Condición If</div>
+          <div class="activity" draggable="true" data-type="for">Bucle For Each</div>
+          <div class="activity" draggable="true" data-type="while">Bucle While</div>
+          <div class="activity" draggable="true" data-type="wait">Esperar</div>
+          <div class="activity" draggable="true" data-type="end">Fin</div>
+        </section>
+
+        <section class="group">
+          <h3>Navegador Web</h3>
+          <div class="activity" draggable="true" data-type="open-browser">Abrir Navegador</div>
+          <div class="activity" draggable="true" data-type="click">Click Elemento</div>
+          <div class="activity" draggable="true" data-type="write">Escribir Texto</div>
+        </section>
+      </aside>
+
+      <section class="canvas-wrap">
+        <div id="canvas" class="canvas" aria-label="Diseñador de flujo"></div>
+        <div class="zoom">100%</div>
+      </section>
+
+      <aside class="properties">
+        <h3>Propiedades</h3>
+        <p id="propEmpty">Selecciona un bloque para editar.</p>
+        <form id="propForm" class="hidden">
+          <label>
+            Nombre
+            <input id="propName" />
+          </label>
+          <label>
+            Parámetros (JSON)
+            <textarea id="propParams" rows="6"></textarea>
+          </label>
+          <button type="submit" class="primary small">Aplicar cambios</button>
+        </form>
+      </aside>
+    </main>
+
+    <footer>
+      <strong>Log de ejecución</strong>
+      <pre id="log">Listo para ejecutar...</pre>
+    </footer>
+
+    <script src="./app.js"></script>
+  </body>
+</html>

--- a/rpa_studio/style.css
+++ b/rpa_studio/style.css
@@ -1,0 +1,211 @@
+:root {
+  color-scheme: light;
+  --bg: #f3f4f8;
+  --card: #ffffff;
+  --line: #d8dce7;
+  --text: #1f2a44;
+  --muted: #7a849b;
+  --primary: #6b4df6;
+  --primary-soft: #ece8ff;
+}
+
+* {
+  box-sizing: border-box;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, Segoe UI, sans-serif;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  min-height: 100vh;
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+}
+
+.topbar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 16px;
+  background: var(--card);
+  border-bottom: 1px solid var(--line);
+}
+
+#automationName {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 10px;
+  min-width: 320px;
+  font-size: 1rem;
+}
+
+.actions {
+  margin-left: auto;
+  display: flex;
+  gap: 8px;
+}
+
+button {
+  border: 1px solid var(--line);
+  background: var(--card);
+  border-radius: 10px;
+  padding: 10px 14px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+button.primary {
+  background: var(--primary);
+  color: #fff;
+  border-color: var(--primary);
+}
+
+button.small {
+  padding: 8px 10px;
+}
+
+.icon-btn {
+  width: 38px;
+  height: 38px;
+  border-radius: 8px;
+}
+
+.workspace {
+  display: grid;
+  grid-template-columns: 280px 1fr 280px;
+  min-height: 0;
+}
+
+.sidebar,
+.properties {
+  background: var(--card);
+  border-right: 1px solid var(--line);
+  padding: 12px;
+  overflow: auto;
+}
+
+.properties {
+  border-left: 1px solid var(--line);
+  border-right: 0;
+}
+
+.sidebar h2 {
+  margin: 4px 0 10px;
+  color: var(--muted);
+  letter-spacing: 0.06em;
+  font-size: 0.95rem;
+}
+
+#search {
+  width: 100%;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 10px;
+}
+
+.group h3 {
+  margin: 14px 0 6px;
+}
+
+.activity {
+  background: #f8f9ff;
+  border: 1px solid #e2e5f6;
+  border-radius: 10px;
+  padding: 8px 10px;
+  margin-bottom: 8px;
+  cursor: grab;
+}
+
+.canvas-wrap {
+  position: relative;
+  padding: 20px;
+}
+
+.canvas {
+  background: #eef1f8;
+  border: 2px dashed #d5dbef;
+  border-radius: 14px;
+  height: 100%;
+  min-height: 480px;
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  overflow: auto;
+}
+
+.node {
+  width: 280px;
+  background: #fff;
+  border: 2px solid #e2dafd;
+  border-radius: 14px;
+  padding: 14px;
+  box-shadow: 0 4px 12px rgba(50, 61, 109, 0.06);
+}
+
+.node.selected {
+  border-color: var(--primary);
+  background: var(--primary-soft);
+}
+
+.node-title {
+  font-weight: 700;
+}
+
+.node-subtitle {
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.zoom {
+  position: absolute;
+  right: 26px;
+  bottom: 26px;
+  background: var(--card);
+  border: 1px solid var(--line);
+  padding: 8px 12px;
+  border-radius: 10px;
+  color: var(--muted);
+}
+
+label {
+  display: block;
+  margin-bottom: 10px;
+  font-size: 0.9rem;
+}
+
+label input,
+textarea {
+  width: 100%;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 8px;
+  margin-top: 4px;
+}
+
+.hidden {
+  display: none;
+}
+
+footer {
+  background: #171d2d;
+  color: #d7deff;
+  padding: 10px 16px;
+}
+
+pre {
+  margin: 8px 0 0;
+  max-height: 120px;
+  overflow: auto;
+}
+
+@media (max-width: 1100px) {
+  .workspace {
+    grid-template-columns: 240px 1fr;
+  }
+
+  .properties {
+    display: none;
+  }
+}


### PR DESCRIPTION
### Motivation
- Proporcionar un prototipo visual tipo UiPath/Rocketbot/Blue Prism para diseñar flujos RPA como un MVP de estudio visual.
- Facilitar iteración rápida sobre la interfaz (canvas, actividades y propiedades) sin integrar aún un motor de ejecución real.

### Description
- Se añadió la mini‑app `rpa_studio/` con la UI y recursos: `rpa_studio/index.html`, `rpa_studio/style.css`, `rpa_studio/app.js` y `rpa_studio/README.md`.
- Implementa drag & drop de actividades al canvas, listado de nodos, selección y edición de propiedades (nombre y `params` en JSON) en el inspector.
- Añade simulación de ejecución que muestra un log con la secuencia de pasos y permite exportar la automatización a un archivo JSON descargable.
- Incluye búsqueda/filtrado de actividades, estilos responsive básicos y documentación de ejecución local (`python3 -m http.server 8000`).

### Testing
- `node --check rpa_studio/app.js` se ejecutó y devolvió `OK` (sintaxis JS verificada correctamente).
- Se intentó iniciar un servidor local con `python3 -m http.server 8000` dentro de un comando con `timeout`; el proceso terminó con código `124` por el `timeout` intencional para no dejar el servidor en background, por lo que la verificación de arranque se deja como prueba manual usando `python3 -m http.server 8000` y abrir `http://localhost:8000/rpa_studio/`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c090cd89a88327af8e7cac03014f6d)